### PR TITLE
Fix fail on empty files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-shiphawk-plugin (1.0.7)
+    danger-shiphawk-plugin (1.0.9)
       danger
       rubocop
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -43,9 +43,12 @@ module Danger
     end
 
     def detect_offenses
-      rubocop_output = json_parse(rubocop)
+      files_string = files_to_lint
 
-      all_offenses = rubocop_output.files.flat_map do |file|
+      return [] if files_string.empty?
+      rubocop_output = call_rubocop(files_string)
+
+      all_offenses = json_parse(rubocop_output).files.flat_map do |file|
         offenses = file.offenses
         next [] if offenses.empty?
 
@@ -61,14 +64,14 @@ module Danger
       all_offenses.sort_by(&:serenity)
     end
 
-    def rubocop
+    def call_rubocop(files_string)
       command = ['bundle', 'exec']
       command += ['rubocop']
       command += ['--force-exclusion']
       command += ['--format', 'json']
       command += ['--config', @config.shellescape] if @config
 
-      `#{command.join(' ')} #{files_to_lint}`
+      `#{command.join(' ')} #{files_string}`
     end
 
     def files_to_lint

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Danger
   module ShipHawkPlugin
-    VERSION = '1.0.8'
+    VERSION = '1.0.9'
   end
 end

--- a/spec/danger_shiphawk_plugin_spec.rb
+++ b/spec/danger_shiphawk_plugin_spec.rb
@@ -71,6 +71,15 @@ describe Danger::ShiphawkPlugin do
 
         @shiphawk_plugin.checkup(files: 'diff')
       end
+
+      it 'has no diff' do
+        expect(@shiphawk_plugin.git).to receive(:modified_files).and_return([])
+        expect(@shiphawk_plugin.git).to receive(:added_files).and_return([])
+
+        expect_any_instance_of(described_class).to_not receive(:`)
+
+        @shiphawk_plugin.checkup(files: 'diff')
+      end
     end
 
     context 'offenses' do

--- a/spec/danger_shiphawk_plugin_spec.rb
+++ b/spec/danger_shiphawk_plugin_spec.rb
@@ -50,14 +50,14 @@ describe Danger::ShiphawkPlugin do
     context 'rubocop launch' do
       it 'with format only' do
         expect_any_instance_of(described_class).to receive(:`)
-          .with('bundle exec rubocop --format json .').and_return(rubocop_response_blank)
+          .with('bundle exec rubocop --force-exclusion --format json .').and_return(rubocop_response_blank)
 
         @shiphawk_plugin.checkup
       end
 
       it 'with config-file' do
         expect_any_instance_of(described_class).to receive(:`)
-          .with('bundle exec rubocop --format json --config hello.txt .').and_return(rubocop_response_blank)
+          .with('bundle exec rubocop --force-exclusion --format json --config hello.txt .').and_return(rubocop_response_blank)
 
         @shiphawk_plugin.checkup(config: 'hello.txt')
       end
@@ -67,7 +67,7 @@ describe Danger::ShiphawkPlugin do
         expect(@shiphawk_plugin.git).to receive(:added_files).and_return(['log/temp.rb'])
 
         expect_any_instance_of(described_class).to receive(:`)
-          .with('bundle exec rubocop --format json temp.rb log/temp.rb').and_return(rubocop_response_blank)
+          .with('bundle exec rubocop --force-exclusion --format json temp.rb log/temp.rb').and_return(rubocop_response_blank)
 
         @shiphawk_plugin.checkup(files: 'diff')
       end
@@ -76,7 +76,7 @@ describe Danger::ShiphawkPlugin do
     context 'offenses' do
       before do
         expect_any_instance_of(described_class).to receive(:`)
-          .with('bundle exec rubocop --format json .').and_return(rubocop_response_with_errors)
+          .with('bundle exec rubocop --force-exclusion --format json .').and_return(rubocop_response_with_errors)
       end
 
       it 'check errors messages' do


### PR DESCRIPTION
When we create an MR Request which does not contain any modified/added files 

This plugin fails.

For example: [Link](https://git.shiphawk.com/shiphawk/shiphawk-dev/-/merge_requests/9667)